### PR TITLE
Add Tati Cycles to bike manufacturers list

### DIFF
--- a/manufacturers.csv
+++ b/manufacturers.csv
@@ -973,6 +973,7 @@ name,website,frame_maker,open_year,close_year,logo_url
 "Tamer", "", "", "", "", 
 "Tange-Seiki", "", "", "", "", 
 "Tangent Products", "", "", "", "", 
+"Tati Cycles","http://www.taticycles.com/","false","2006","","http://taticycles.com/templates/theworldin35mm/images/logo.jpg",
 "Tec Labs", "", "", "", "", 
 "Tektro", "", "", "", "", 
 "Tern", "http://www.ternbicycles.com/us/", "true", "", "", 


### PR DESCRIPTION
Hi-
Just adding Tati Cycles, a shop in Chicago with house-brand bikes, to the bike manufacturers list.
Thanks for your work!
M
