### PR TITLE
Move frame_materials into vehicle_attributes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,7 +8,6 @@ The data here is used by [BikeIndex.org](https://bikeindex.org) to classify bike
 - Components: [components.csv](data/components.csv)
 - Vehicle attributes: [vehicle_attributes.csv](data/vehicle_attributes.csv)
 - Colors: [colors.csv](data/colors.csv)
-- Frame materials: [frame_materials.csv](data/frame_materials.csv)
 - Gear types: [gear_types.csv](data/gear_types.csv)
 - Handlebar types: [handlebar_types.csv](data/handlebar_types.csv)
 

--- a/data/frame_materials.csv
+++ b/data/frame_materials.csv
@@ -1,7 +1,0 @@
-name,slug
-Steel,steel
-Aluminum,aluminum
-Carbon or composite,composite
-Titanium,titanium
-Magnesium,magnesium
-Wood or organic material,organic

--- a/data/vehicle_attributes.csv
+++ b/data/vehicle_attributes.csv
@@ -1,4 +1,4 @@
-attribute,name,description,motorized (always/never/can_be),pedal (always/never/can_be)
+attribute,name,description,motorized (always/never/can_be),pedal (always/never/can_be),slug
 vehicle_type,Bike,,can_be,always
 vehicle_type,Tandem,,can_be,always
 vehicle_type,Unicycle,,can_be,always
@@ -27,3 +27,9 @@ propulsion_type,Throttle,,always,can_be
 propulsion_type,Pedal Assist and Throttle,,always,always
 propulsion_type,Hand Cycle,Hand Cycle (hand pedal),never,always
 propulsion_type,Human powered,Human powered (not by pedals),never,never
+frame_material,Steel,,,,steel
+frame_material,Aluminum,,,,aluminum
+frame_material,Carbon or composite,,,,composite
+frame_material,Titanium,,,,titanium
+frame_material,Magnesium,,,,magnesium
+frame_material,Wood or organic material,,,,organic

--- a/tests/csvs_spec.rb
+++ b/tests/csvs_spec.rb
@@ -65,15 +65,6 @@ RSpec.describe "CSVs" do
     end
   end
 
-  describe "frame_materials.csv" do
-    let(:repo_csv) { CSV.read("data/frame_materials.csv", headers: true, header_converters: :symbol) }
-
-    it "can be read" do
-      expect(repo_csv.headers).not_to be_empty
-      expect(repo_csv.count).to be > 0
-    end
-  end
-
   describe "gear_types.csv" do
     let(:repo_csv) { CSV.read("data/gear_types.csv", headers: true, header_converters: :symbol) }
 


### PR DESCRIPTION
Merges the frame materials data into `data/vehicle_attributes.csv` under a new `frame_material` attribute value, adding a `slug` column to preserve the non-derivable slugs (e.g. `Carbon or composite → composite`, `Wood or organic material → organic`). The standalone `data/frame_materials.csv` is removed, along with its test block in `tests/csvs_spec.rb` and its entry in the README.