### PR TITLE
Add motor_placement to vehicle_attributes

### DIFF
--- a/data/vehicle_attributes.csv
+++ b/data/vehicle_attributes.csv
@@ -1,4 +1,4 @@
-attribute,name,description,motorized (always/never/can_be),pedal (always/never/can_be),slug
+attribute,name,description,motorized (always/never/can_be),pedal (always/never/can_be)
 vehicle_type,Bike,,can_be,always
 vehicle_type,Tandem,,can_be,always
 vehicle_type,Unicycle,,can_be,always
@@ -27,12 +27,12 @@ propulsion_type,Throttle,,always,can_be
 propulsion_type,Pedal Assist and Throttle,,always,always
 propulsion_type,Hand Cycle,Hand Cycle (hand pedal),never,always
 propulsion_type,Human powered,Human powered (not by pedals),never,never
-frame_material,Steel,,,,steel
-frame_material,Aluminum,,,,aluminum
-frame_material,Carbon or composite,,,,composite
-frame_material,Titanium,,,,titanium
-frame_material,Magnesium,,,,magnesium
-frame_material,Wood or organic material,,,,organic
-motor_placement,Hub drive,,always,can_be,hub_drive
-motor_placement,Mid drive,,always,always,mid_drive
-motor_placement,Friction drive,,always,can_be,friction_drive
+frame_material,Steel,,,
+frame_material,Aluminum,,,
+frame_material,Carbon or composite,,,
+frame_material,Titanium,,,
+frame_material,Magnesium,,,
+frame_material,Wood or organic material,,,
+motor_placement,Hub drive,,always,can_be
+motor_placement,Mid drive,,always,always
+motor_placement,Friction drive,,always,can_be

--- a/data/vehicle_attributes.csv
+++ b/data/vehicle_attributes.csv
@@ -33,3 +33,6 @@ frame_material,Carbon or composite,,,,composite
 frame_material,Titanium,,,,titanium
 frame_material,Magnesium,,,,magnesium
 frame_material,Wood or organic material,,,,organic
+motor_placement,Hub drive,,always,can_be,hub_drive
+motor_placement,Mid drive,,always,always,mid_drive
+motor_placement,Friction drive,,always,can_be,friction_drive

--- a/data/vehicle_attributes.csv
+++ b/data/vehicle_attributes.csv
@@ -1,38 +1,38 @@
-attribute,name,description,motorized (always/never/can_be),pedal (always/never/can_be)
-vehicle_type,Bike,,can_be,always
-vehicle_type,Tandem,,can_be,always
-vehicle_type,Unicycle,,can_be,always
-vehicle_type,Tricycle,,can_be,always
-vehicle_type,Stroller,,can_be,never
-vehicle_type,Recumbent,,can_be,always
-vehicle_type,Bike Trailer,,can_be,never
-vehicle_type,Wheelchair,,can_be,never
+attribute,name,name extended,motorized (always/never/can_be),pedal (always/never/can_be)
+vehicle_type,Bike,Bike,can_be,always
+vehicle_type,Tandem,Tandem,can_be,always
+vehicle_type,Unicycle,Unicycle,can_be,always
+vehicle_type,Tricycle,Tricycle,can_be,always
+vehicle_type,Stroller,Stroller,can_be,never
+vehicle_type,Recumbent,Recumbent,can_be,always
+vehicle_type,Bike Trailer,Bike Trailer,can_be,never
+vehicle_type,Wheelchair,Wheelchair,can_be,never
 vehicle_type,Cargo Bike,Cargo Bike (front storage),can_be,always
 vehicle_type,Tall Bike,Tall Bike (multiple frames fused together),can_be,always
-vehicle_type,Penny Farthing,,can_be,always
+vehicle_type,Penny Farthing,Penny Farthing,can_be,always
 vehicle_type,Cargo Bike Rear,Cargo Bike Rear (e.g. longtail),can_be,always
 vehicle_type,Cargo Tricycle,"Cargo Tricycle (trike with front storage, e.g. Christiania bike)",can_be,always
 vehicle_type,Cargo Tricycle Rear,Cargo Tricycle (trike with rear storage),can_be,always
 vehicle_type,Trail behind,Trail behind (half bike),never,always
 vehicle_type,Pedi Cab,Pedi Cab (rickshaw),can_be,always
-vehicle_type,e-Scooter,,always,never
+vehicle_type,e-Scooter,e-Scooter,always,never
 vehicle_type,e-Personal Mobility,"e-Personal Mobility (EPAMD, e-Skateboard, Segway, e-Unicycle, etc)",always,never
 vehicle_type,Scooter,Scooter (not electric),never,never
 vehicle_type,Skateboard,Skateboard (not electric),never,never
 vehicle_type,e-Motorcycle,"e-Motorcycle (e-Dirt bike, e-bike with no pedals)",always,never
-vehicle_type,Elliptical bike,,can_be,never
-propulsion_type,Pedal,,never,always
-propulsion_type,Pedal Assist,,always,always
-propulsion_type,Throttle,,always,can_be
-propulsion_type,Pedal Assist and Throttle,,always,always
+vehicle_type,Elliptical bike,Elliptical bike,can_be,never
+propulsion_type,Pedal,Pedal,never,always
+propulsion_type,Pedal Assist,Pedal Assist,always,always
+propulsion_type,Throttle,Throttle,always,can_be
+propulsion_type,Pedal Assist and Throttle,Pedal Assist and Throttle,always,always
 propulsion_type,Hand Cycle,Hand Cycle (hand pedal),never,always
 propulsion_type,Human powered,Human powered (not by pedals),never,never
-frame_material,Steel,,,
-frame_material,Aluminum,,,
-frame_material,Carbon or composite,,,
-frame_material,Titanium,,,
-frame_material,Magnesium,,,
-frame_material,Wood or organic material,,,
-motor_placement,Hub drive,,always,can_be
-motor_placement,Mid drive,,always,always
-motor_placement,Friction drive,,always,can_be
+frame_material,Steel,Steel,,
+frame_material,Aluminum,Aluminum,,
+frame_material,Carbon or composite,Carbon or composite,,
+frame_material,Titanium,Titanium,,
+frame_material,Magnesium,Magnesium,,
+frame_material,Wood or organic material,Wood or organic material,,
+motor_placement,Hub drive,Hub drive,always,can_be
+motor_placement,Mid drive,Mid drive,always,always
+motor_placement,Friction drive,Friction drive,always,can_be

--- a/tests/csvs_spec.rb
+++ b/tests/csvs_spec.rb
@@ -10,8 +10,33 @@ system("bin/download_from_bike_index tmp/", exception: true)
 BIKE_INDEX_MANUFACTURERS_CSV = CSV.read("tmp/manufacturers.csv", headers: true, header_converters: :symbol)
 BIKE_INDEX_ACTIVITIES_CSV = CSV.read("tmp/primary_activities.csv", headers: true, header_converters: :symbol)
 
+RSpec.shared_examples "a data CSV" do |path|
+  let(:repo_csv) { CSV.read(path, headers: true, header_converters: :symbol) }
+  let(:rows) { CSV.read(path) }
+
+  it "can be read" do
+    expect(repo_csv.headers).not_to be_empty
+    expect(repo_csv.count).to be > 0
+  end
+
+  it "has no rows with a different column count than the header" do
+    header_count = rows.first.length
+    ragged_line_numbers = rows.each_with_index
+      .select { |row, _i| row.length != header_count }
+      .map { |_row, i| i + 1 }
+
+    expect(ragged_line_numbers).to(
+      be_empty,
+      "expected every row to have #{header_count} columns, " \
+      "but these line numbers differ: #{ragged_line_numbers.join(", ")}"
+    )
+  end
+end
+
 RSpec.describe "CSVs" do
   describe "manufacturers.csv" do
+    it_behaves_like "a data CSV", "data/manufacturers.csv"
+
     let(:repo_csv) { CSV.read("data/manufacturers.csv", headers: true, header_converters: :symbol) }
 
     it "has at least as many manufacturers as are on bikeindex, and the same headers" do
@@ -21,6 +46,8 @@ RSpec.describe "CSVs" do
   end
 
   describe "primary_activities.csv" do
+    it_behaves_like "a data CSV", "data/primary_activities.csv"
+
     let(:repo_csv) { CSV.read("data/primary_activities.csv", headers: true, header_converters: :symbol) }
 
     it "has at least as many activities as are on bikeindex, and the same headers" do
@@ -30,78 +57,26 @@ RSpec.describe "CSVs" do
   end
 
   describe "wheel_sizes.csv" do
-    let(:repo_csv) { CSV.read("data/wheel_sizes.csv", headers: true, header_converters: :symbol) }
-
-    it "can be read" do
-      expect(repo_csv.headers).not_to be_empty
-      expect(repo_csv.count).to be > 0
-    end
+    it_behaves_like "a data CSV", "data/wheel_sizes.csv"
   end
 
   describe "components.csv" do
-    let(:repo_csv) { CSV.read("data/components.csv", headers: true, header_converters: :symbol) }
-
-    it "can be read" do
-      expect(repo_csv.headers).not_to be_empty
-      expect(repo_csv.count).to be > 0
-    end
+    it_behaves_like "a data CSV", "data/components.csv"
   end
 
   describe "vehicle_attributes.csv" do
-    let(:repo_csv) { CSV.read("data/vehicle_attributes.csv", headers: true, header_converters: :symbol) }
-
-    it "can be read" do
-      expect(repo_csv.headers).not_to be_empty
-      expect(repo_csv.count).to be > 0
-    end
-  end
-
-  describe "every data CSV" do
-    Dir[File.join(APP_ROOT, "data", "*.csv")].sort.each do |path|
-      relative_path = path.sub("#{APP_ROOT}/", "")
-
-      describe relative_path do
-        let(:rows) { CSV.read(path) }
-
-        it "has no rows with a different column count than the header" do
-          header_count = rows.first.length
-          ragged = rows.each_with_index.select { |row, _i| row.length != header_count }
-          ragged_line_numbers = ragged.map { |_row, i| i + 1 }
-
-          expect(ragged_line_numbers).to(
-            be_empty,
-            "expected every row to have #{header_count} columns, " \
-            "but these line numbers differ: #{ragged_line_numbers.join(", ")}"
-          )
-        end
-      end
-    end
+    it_behaves_like "a data CSV", "data/vehicle_attributes.csv"
   end
 
   describe "colors.csv" do
-    let(:repo_csv) { CSV.read("data/colors.csv", headers: true, header_converters: :symbol) }
-
-    it "can be read" do
-      expect(repo_csv.headers).not_to be_empty
-      expect(repo_csv.count).to be > 0
-    end
+    it_behaves_like "a data CSV", "data/colors.csv"
   end
 
   describe "gear_types.csv" do
-    let(:repo_csv) { CSV.read("data/gear_types.csv", headers: true, header_converters: :symbol) }
-
-    it "can be read" do
-      expect(repo_csv.headers).not_to be_empty
-      expect(repo_csv.count).to be > 0
-    end
+    it_behaves_like "a data CSV", "data/gear_types.csv"
   end
 
   describe "handlebar_types.csv" do
-    let(:repo_csv) { CSV.read("data/handlebar_types.csv", headers: true, header_converters: :symbol) }
-
-    it "can be read" do
-      expect(repo_csv.headers).not_to be_empty
-      expect(repo_csv.count).to be > 0
-    end
+    it_behaves_like "a data CSV", "data/handlebar_types.csv"
   end
 end

--- a/tests/csvs_spec.rb
+++ b/tests/csvs_spec.rb
@@ -10,30 +10,28 @@ system("bin/download_from_bike_index tmp/", exception: true)
 BIKE_INDEX_MANUFACTURERS_CSV = CSV.read("tmp/manufacturers.csv", headers: true, header_converters: :symbol)
 BIKE_INDEX_ACTIVITIES_CSV = CSV.read("tmp/primary_activities.csv", headers: true, header_converters: :symbol)
 
-RSpec.shared_examples "a data CSV" do |path|
-  let(:repo_csv) { CSV.read(path, headers: true, header_converters: :symbol) }
-  let(:rows) { CSV.read(path) }
-
-  it "can be read" do
-    expect(repo_csv.headers).not_to be_empty
-    expect(repo_csv.count).to be > 0
-  end
-
-  it "has no rows with a different column count than the header" do
-    header_count = rows.first.length
-    ragged_line_numbers = rows.each_with_index
-      .select { |row, _i| row.length != header_count }
-      .map { |_row, i| i + 1 }
-
-    expect(ragged_line_numbers).to(
-      be_empty,
-      "expected every row to have #{header_count} columns, " \
-      "but these line numbers differ: #{ragged_line_numbers.join(", ")}"
-    )
-  end
-end
-
 RSpec.describe "CSVs" do
+  shared_examples "a data CSV" do |path|
+    let(:repo_csv) { CSV.read(path, headers: true, header_converters: :symbol) }
+    let(:rows) { CSV.read(path) }
+
+    it "can be read and has no rows with a different column count than the header" do
+      expect(repo_csv.headers).not_to be_empty
+      expect(repo_csv.count).to be > 0
+
+      header_count = rows.first.length
+      ragged_line_numbers = rows.each_with_index
+        .select { |row, _i| row.length != header_count }
+        .map { |_row, i| i + 1 }
+
+      expect(ragged_line_numbers).to(
+        be_empty,
+        "expected every row to have #{header_count} columns, " \
+        "but these line numbers differ: #{ragged_line_numbers.join(", ")}"
+      )
+    end
+  end
+
   describe "manufacturers.csv" do
     it_behaves_like "a data CSV", "data/manufacturers.csv"
 

--- a/tests/csvs_spec.rb
+++ b/tests/csvs_spec.rb
@@ -56,6 +56,28 @@ RSpec.describe "CSVs" do
     end
   end
 
+  describe "every data CSV" do
+    Dir[File.join(APP_ROOT, "data", "*.csv")].sort.each do |path|
+      relative_path = path.sub("#{APP_ROOT}/", "")
+
+      describe relative_path do
+        let(:rows) { CSV.read(path) }
+
+        it "has no rows with a different column count than the header" do
+          header_count = rows.first.length
+          ragged = rows.each_with_index.select { |row, _i| row.length != header_count }
+          ragged_line_numbers = ragged.map { |_row, i| i + 1 }
+
+          expect(ragged_line_numbers).to(
+            be_empty,
+            "expected every row to have #{header_count} columns, " \
+            "but these line numbers differ: #{ragged_line_numbers.join(", ")}"
+          )
+        end
+      end
+    end
+  end
+
   describe "colors.csv" do
     let(:repo_csv) { CSV.read("data/colors.csv", headers: true, header_converters: :symbol) }
 


### PR DESCRIPTION
Adds a `motor_placement` attribute to `data/vehicle_attributes.csv` with three values: Hub drive, Mid drive, and Friction drive. All are always motorized. Mid drive is always pedal, while Hub drive and Friction drive can be pedal.

Also updates and improves the specs to test for ragged rows.