### PR TITLE
Title-case name values in taxonomy CSVs

### DIFF
--- a/data/colors.csv
+++ b/data/colors.csv
@@ -7,8 +7,8 @@ Orange,orange,#ff8d1d
 Pink,pink,#ff7dfd
 Purple,purple,#a745c0
 Red,red,#ec1313
-"Silver, gray or bare metal",silver,#b0b0b0
-Stickers tape or other cover-up,stickers,
+"Silver, Gray or Bare Metal",silver,#b0b0b0
+Stickers Tape or Other Cover-Up,stickers,
 Teal,teal,#3bede7
 White,white,#fff
 Yellow or Gold,yellow,#fff44b

--- a/data/components.csv
+++ b/data/components.csv
@@ -1,22 +1,22 @@
 name,secondary_name,has_multiple_locations,group
-unknown,,false,Additional parts
-Water Bottle Cage,,false,Additional parts
-Stem,Gooseneck,false,Additional parts
+unknown,,false,Additional Parts
+Water Bottle Cage,,false,Additional Parts
+Stem,Gooseneck,false,Additional Parts
 Bashguard/Chain Guide,,false,Drivetrain
 Fairing,,false,Frame and Fork
-Lights,,true,Additional parts
-Bell/Noisemaker,,false,Additional parts
+Lights,,true,Additional Parts
+Bell/Noisemaker,,false,Additional Parts
 Basket,,true,Cargo
 Chain Tensioners,Chain Tugs,false,Drivetrain
 Derailleur,,false,Drivetrain
 Training Wheels,,false,Wheels
 Bottom Bracket,,false,Drivetrain
 Brake,,true,Brakes
-Hub Guard,,false,Additional parts
+Hub Guard,,false,Additional Parts
 Generator/Dynamo,,true,Wheels
-Handlebar,,false,Additional parts
+Handlebar,,false,Additional Parts
 Wheel,,true,Wheels
-Saddle,,false,Additional parts
+Saddle,,false,Additional Parts
 Rim,,true,Wheels
 Axle Nuts,,true,Wheels
 Hub,,true,Wheels
@@ -38,17 +38,17 @@ Chainrings,,false,Drivetrain
 Cog/Cassette/Freewheel,,false,Drivetrain
 Crankset,,false,Drivetrain
 Pedals,,false,Drivetrain
-Computer,,false,Additional parts
-Pegs,,true,Additional parts
-Toe Clips,,false,Additional parts
-Grips/Tape,,false,Additional parts
-Seatpost Clamp,,false,Additional parts
+Computer,,false,Additional Parts
+Pegs,,true,Additional Parts
+Toe Clips,,false,Additional Parts
+Grips/Tape,,false,Additional Parts
+Seatpost Clamp,,false,Additional Parts
 Detangler,,false,Brakes
-Kickstand,,false,Additional parts
+Kickstand,,false,Additional Parts
 Rack,,true,Cargo
-Seatpost,,false,Additional parts
-Fender,,true,Additional parts
-Aero Bars/Extensions/Bar Ends,Aero Bars,false,Additional parts
+Seatpost,,false,Additional Parts
+Fender,,true,Additional Parts
+Aero Bars/Extensions/Bar Ends,Aero Bars,false,Additional Parts
 Ebike Battery,Electric Bike Battery,false,Drivetrain
 Ebike Motor,Electric Bike Motor,false,Drivetrain
 Pannier,Rack Bag,false,Cargo

--- a/data/gear_types.csv
+++ b/data/gear_types.csv
@@ -2,8 +2,8 @@ position (front/rear/both),name,count,internal
 front,1,1,false
 front,2,2,false
 front,3,3,false
-front,2 internal,2,true
-front,3 internal,3,true
+front,2 Internal,2,true
+front,3 Internal,3,true
 rear,1,1,false
 rear,2,2,false
 rear,3,3,false
@@ -17,23 +17,23 @@ rear,10,10,false
 rear,11,11,false
 rear,12,12,false
 rear,Fixed,1,false
-rear,1 internal,1,true
-rear,2 internal,2,true
-rear,3 internal,3,true
-rear,4 internal,4,true
-rear,5 internal,5,true
-rear,6 internal,6,true
-rear,7 internal,7,true
-rear,8 internal,8,true
-rear,9 internal,9,true
-rear,10 internal,10,true
-rear,11 internal,11,true
-rear,12 internal,12,true
+rear,1 Internal,1,true
+rear,2 Internal,2,true
+rear,3 Internal,3,true
+rear,4 Internal,4,true
+rear,5 Internal,5,true
+rear,6 Internal,6,true
+rear,7 Internal,7,true
+rear,8 Internal,8,true
+rear,9 Internal,9,true
+rear,10 Internal,10,true
+rear,11 Internal,11,true
+rear,12 Internal,12,true
 rear,13,13,false
 rear,14,14,false
-rear,13 internal,13,true
-rear,14 internal,14,true
-rear,Continuously variable,0,true
+rear,13 Internal,13,true
+rear,14 Internal,14,true
+rear,Continuously Variable,0,true
 both,Belt Drive,1,false
 rear,Coaster Brake,1,true
 both,Shaft Drive,1,true

--- a/data/handlebar_types.csv
+++ b/data/handlebar_types.csv
@@ -1,7 +1,7 @@
 name,slug
-Drop bars,drop_bar
-Forward facing,forward
-Rear facing,rearward
-Not handlebars,other
-BMX style,bmx
-Flat or riser,flat
+Drop Bars,drop_bar
+Forward Facing,forward
+Rear Facing,rearward
+Not Handlebars,other
+BMX Style,bmx
+Flat or Riser,flat

--- a/data/primary_activities.csv
+++ b/data/primary_activities.csv
@@ -1,36 +1,36 @@
 flavor,families
-Commuting (around town / hybrid),
+Commuting (Around Town / Hybrid),
 Bike Polo,
 Fixed Gear Freestyle,
 Gravel,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc."
 Cyclocross,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc."
 Bikepacking,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & MTB (Mountain Biking)"
-Bike touring,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & Road biking"
-Randonneuring,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & Road biking"
-All road,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & Road biking"
+Bike Touring,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & Road Biking"
+Randonneuring,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & Road Biking"
+All Road,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & Road Biking"
 Monster Cross,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc."
-Triathalon,Road biking
-Time Trial,Road biking & Track racing
-Criterium,Road biking
-Climbing,Road biking
-Aero,Road biking
-Endurance / Sportive,Road biking
+Triathalon,Road Biking
+Time Trial,Road Biking & Track Racing
+Criterium,Road Biking
+Climbing,Road Biking
+Aero,Road Biking
+Endurance / Sportive,Road Biking
 Trail / All-Mountain,MTB (Mountain Biking)
 Cross-Country (XC),MTB (Mountain Biking)
 Enduro,MTB (Mountain Biking)
 Downhill,MTB (Mountain Biking)
 Freeride,MTB (Mountain Biking)
-Child carrying,Cargo
+Child Carrying,Cargo
 Commercial,Cargo
 Race,BMX
 Freestyle,BMX
 Flatland,BMX
 Cruiser,BMX
-Pursuit,Track racing
-Sprint,Track racing
-Keirin / NJS,Track racing
-Slopestyle,DJ (Dirt jumping)
-4X/Dual Slalom,DJ (Dirt jumping)
+Pursuit,Track Racing
+Sprint,Track Racing
+Keirin / NJS,Track Racing
+Slopestyle,DJ (Dirt Jumping)
+4X/Dual Slalom,DJ (Dirt Jumping)
 Street Trials,Trials
 Pure Trials,Trials
-Artistic cycling,
+Artistic Cycling,

--- a/data/vehicle_attributes.csv
+++ b/data/vehicle_attributes.csv
@@ -7,32 +7,32 @@ vehicle_type,Stroller,Stroller,can_be,never
 vehicle_type,Recumbent,Recumbent,can_be,always
 vehicle_type,Bike Trailer,Bike Trailer,can_be,never
 vehicle_type,Wheelchair,Wheelchair,can_be,never
-vehicle_type,Cargo Bike,Cargo Bike (front storage),can_be,always
-vehicle_type,Tall Bike,Tall Bike (multiple frames fused together),can_be,always
+vehicle_type,Cargo Bike,Cargo Bike (Front Storage),can_be,always
+vehicle_type,Tall Bike,Tall Bike (Multiple Frames Fused Together),can_be,always
 vehicle_type,Penny Farthing,Penny Farthing,can_be,always
-vehicle_type,Cargo Bike Rear,Cargo Bike Rear (e.g. longtail),can_be,always
-vehicle_type,Cargo Tricycle,"Cargo Tricycle (trike with front storage, e.g. Christiania bike)",can_be,always
-vehicle_type,Cargo Tricycle Rear,Cargo Tricycle (trike with rear storage),can_be,always
-vehicle_type,Trail behind,Trail behind (half bike),never,always
-vehicle_type,Pedi Cab,Pedi Cab (rickshaw),can_be,always
+vehicle_type,Cargo Bike Rear,Cargo Bike Rear (e.g. Longtail),can_be,always
+vehicle_type,Cargo Tricycle,"Cargo Tricycle (Trike with Front Storage, e.g. Christiania Bike)",can_be,always
+vehicle_type,Cargo Tricycle Rear,Cargo Tricycle (Trike with Rear Storage),can_be,always
+vehicle_type,Trail Behind,Trail Behind (Half Bike),never,always
+vehicle_type,Pedi Cab,Pedi Cab (Rickshaw),can_be,always
 vehicle_type,e-Scooter,e-Scooter,always,never
 vehicle_type,e-Personal Mobility,"e-Personal Mobility (EPAMD, e-Skateboard, Segway, e-Unicycle, etc)",always,never
-vehicle_type,Scooter,Scooter (not electric),never,never
-vehicle_type,Skateboard,Skateboard (not electric),never,never
-vehicle_type,e-Motorcycle,"e-Motorcycle (e-Dirt bike, e-bike with no pedals)",always,never
-vehicle_type,Elliptical bike,Elliptical bike,can_be,never
+vehicle_type,Scooter,Scooter (Not Electric),never,never
+vehicle_type,Skateboard,Skateboard (Not Electric),never,never
+vehicle_type,e-Motorcycle,"e-Motorcycle (e-Dirt Bike, e-Bike with No Pedals)",always,never
+vehicle_type,Elliptical Bike,Elliptical Bike,can_be,never
 propulsion_type,Pedal,Pedal,never,always
 propulsion_type,Pedal Assist,Pedal Assist,always,always
 propulsion_type,Throttle,Throttle,always,can_be
 propulsion_type,Pedal Assist and Throttle,Pedal Assist and Throttle,always,always
-propulsion_type,Hand Cycle,Hand Cycle (hand pedal),never,always
-propulsion_type,Human powered,Human powered (not by pedals),never,never
+propulsion_type,Hand Cycle,Hand Cycle (Hand Pedal),never,always
+propulsion_type,Human Powered,Human Powered (Not by Pedals),never,never
 frame_material,Steel,Steel,,
 frame_material,Aluminum,Aluminum,,
-frame_material,Carbon or composite,Carbon or composite,,
+frame_material,Carbon or Composite,Carbon or Composite,,
 frame_material,Titanium,Titanium,,
 frame_material,Magnesium,Magnesium,,
-frame_material,Wood or organic material,Wood or organic material,,
-motor_placement,Hub drive,Hub drive,always,can_be
-motor_placement,Mid drive,Mid drive,always,always
-motor_placement,Friction drive,Friction drive,always,can_be
+frame_material,Wood or Organic Material,Wood or Organic Material,,
+motor_placement,Hub Drive,Hub Drive,always,can_be
+motor_placement,Mid Drive,Mid Drive,always,always
+motor_placement,Friction Drive,Friction Drive,always,can_be


### PR DESCRIPTION
Title-cases the human-readable name columns across the taxonomy CSVs (`colors`, `components`, `gear_types`, `handlebar_types`, `primary_activities`, `vehicle_attributes`), e.g. `Drop bars → Drop Bars`, `N internal → N Internal`, `Road biking → Road Biking`, `Hub drive → Hub Drive`.

Significant words are capitalized while minor words (`or`/`and`/`with`/`by`) stay lowercase, and acronyms (`BMX`, `MTB`), the electric `e-` prefix (`e-Scooter`, `e-Bike`), and `unknown` are left as-is. `manufacturers.csv` (intentional brand casing) and `wheel_sizes.csv` (measurements) are untouched.
