### PR TITLE
Default download_from_bike_index output to data/

### DIFF
--- a/bin/download_from_bike_index
+++ b/bin/download_from_bike_index
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Set default output file
-outfile_manufacturers="manufacturers.csv"
-outfile_activities="primary_activities.csv"
+outfile_manufacturers="data/manufacturers.csv"
+outfile_activities="data/primary_activities.csv"
 
 # Check if an argument was provided (it is the path)
 if [ $# -ge 1 ]; then

--- a/bin/download_from_bike_index
+++ b/bin/download_from_bike_index
@@ -1,16 +1,13 @@
 #!/bin/bash
 
-# Set default output file
-outfile_manufacturers="data/manufacturers.csv"
-outfile_activities="data/primary_activities.csv"
+# Default output directory
+outdir="data/"
 
-# Check if an argument was provided (it is the path)
+# Check if an argument was provided (it is the output directory prefix)
 if [ $# -ge 1 ]; then
-  outfile_path="$1"
-  outfile_manufacturers="${outfile_path}${outfile_manufacturers}"
-  outfile_activities="${outfile_path}${outfile_activities}"
+  outdir="$1"
 fi
 
 # Download the files
-wget -q https://bikeindex.org/manufacturers.csv -O $outfile_manufacturers
-wget -q https://bikeindex.org/primary_activities.csv -O $outfile_activities
+wget -q https://bikeindex.org/manufacturers.csv -O "${outdir}manufacturers.csv"
+wget -q https://bikeindex.org/primary_activities.csv -O "${outdir}primary_activities.csv"

--- a/data/manufacturers.csv
+++ b/data/manufacturers.csv
@@ -770,8 +770,7 @@ Laurin & Klement,,,true,false,,,
 Lazer,,https://lazersport.us/,false,false,,,https://files.bikeindex.org/uploads/Ma/629/lazersport.us
 LDG,Livery Design Gruppe,http://liverydesigngruppe.com/,true,false,,,https://files.bikeindex.org/uploads/Ma/1230/liverydesigngruppe.com
 Leader Bikes,,https://www.leaderbikesusa.com/,true,false,,,https://files.bikeindex.org/uploads/Ma/933/wwwleaderbikeusacom.png
-Lectric Cycles,,https://www.lectriccycles.com/,true,true,,,https://files.bikeindex.org/uploads/Ma/1578/www.lectriccycles.com
-Lectric eBikes,,https://www.lectricebikes.com/,true,true,,,https://files.bikeindex.org/uploads/Ma/1614/www.lectricebikes.com
+Lectric eBikes,,https://lectricebikes.com,true,true,,,https://files.bikeindex.org/uploads/Ma/1614/www.lectricebikes.com
 Leg Lube,,,false,false,,,
 Legacy Frameworks,,https://www.facebook.com/LegacyFrameWorks/,true,false,,,https://files.bikeindex.org/uploads/Ma/952/www.facebook.com
 Lekker,,https://lekkerbikes.com/,true,true,,,https://files.bikeindex.org/uploads/Ma/1765/lekkerbikes.com

--- a/data/primary_activities.csv
+++ b/data/primary_activities.csv
@@ -1,36 +1,36 @@
 flavor,families
-Commuting (Around Town / Hybrid),
+Commuting (around town / hybrid),
 Bike Polo,
 Fixed Gear Freestyle,
 Gravel,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc."
 Cyclocross,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc."
 Bikepacking,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & MTB (Mountain Biking)"
-Bike Touring,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & Road Biking"
-Randonneuring,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & Road Biking"
-All Road,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & Road Biking"
+Bike touring,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & Road biking"
+Randonneuring,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & Road biking"
+All road,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & Road biking"
 Monster Cross,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc."
-Triathalon,Road Biking
-Time Trial,Road Biking & Track Racing
-Criterium,Road Biking
-Climbing,Road Biking
-Aero,Road Biking
-Endurance / Sportive,Road Biking
+Triathalon,Road biking
+Time Trial,Road biking & Track racing
+Criterium,Road biking
+Climbing,Road biking
+Aero,Road biking
+Endurance / Sportive,Road biking
 Trail / All-Mountain,MTB (Mountain Biking)
 Cross-Country (XC),MTB (Mountain Biking)
 Enduro,MTB (Mountain Biking)
 Downhill,MTB (Mountain Biking)
 Freeride,MTB (Mountain Biking)
-Child Carrying,Cargo
+Child carrying,Cargo
 Commercial,Cargo
 Race,BMX
 Freestyle,BMX
 Flatland,BMX
 Cruiser,BMX
-Pursuit,Track Racing
-Sprint,Track Racing
-Keirin / NJS,Track Racing
-Slopestyle,DJ (Dirt Jumping)
-4X/Dual Slalom,DJ (Dirt Jumping)
+Pursuit,Track racing
+Sprint,Track racing
+Keirin / NJS,Track racing
+Slopestyle,DJ (Dirt jumping)
+4X/Dual Slalom,DJ (Dirt jumping)
 Street Trials,Trials
 Pure Trials,Trials
-Artistic Cycling,
+Artistic cycling,

--- a/data/primary_activities.csv
+++ b/data/primary_activities.csv
@@ -1,36 +1,36 @@
 flavor,families
-Commuting (around town / hybrid),
+Commuting (Around Town / Hybrid),
 Bike Polo,
 Fixed Gear Freestyle,
 Gravel,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc."
 Cyclocross,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc."
 Bikepacking,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & MTB (Mountain Biking)"
-Bike touring,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & Road biking"
-Randonneuring,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & Road biking"
-All road,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & Road biking"
+Bike Touring,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & Road Biking"
+Randonneuring,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & Road Biking"
+All Road,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc. & Road Biking"
 Monster Cross,"ATB (All Terrain Biking) — Gravel, Cyclocross, etc."
-Triathalon,Road biking
-Time Trial,Road biking & Track racing
-Criterium,Road biking
-Climbing,Road biking
-Aero,Road biking
-Endurance / Sportive,Road biking
+Triathalon,Road Biking
+Time Trial,Road Biking & Track Racing
+Criterium,Road Biking
+Climbing,Road Biking
+Aero,Road Biking
+Endurance / Sportive,Road Biking
 Trail / All-Mountain,MTB (Mountain Biking)
 Cross-Country (XC),MTB (Mountain Biking)
 Enduro,MTB (Mountain Biking)
 Downhill,MTB (Mountain Biking)
 Freeride,MTB (Mountain Biking)
-Child carrying,Cargo
+Child Carrying,Cargo
 Commercial,Cargo
 Race,BMX
 Freestyle,BMX
 Flatland,BMX
 Cruiser,BMX
-Pursuit,Track racing
-Sprint,Track racing
-Keirin / NJS,Track racing
-Slopestyle,DJ (Dirt jumping)
-4X/Dual Slalom,DJ (Dirt jumping)
+Pursuit,Track Racing
+Sprint,Track Racing
+Keirin / NJS,Track Racing
+Slopestyle,DJ (Dirt Jumping)
+4X/Dual Slalom,DJ (Dirt Jumping)
 Street Trials,Trials
 Pure Trials,Trials
-Artistic cycling,
+Artistic Cycling,


### PR DESCRIPTION
Defaults `bin/download_from_bike_index` to write `manufacturers.csv` and `primary_activities.csv` into `data/`, so a bare run refreshes the canonical copies instead of dropping files in the repo root. The optional path-prefix argument still works as before.

Also refreshes the manufacturer CSV with the latest data from bikeindex.org.
