### PR TITLE
Import components.csv from bike_index

### DIFF
--- a/bin/download_from_bike_index
+++ b/bin/download_from_bike_index
@@ -11,3 +11,4 @@ fi
 # Download the files
 wget -q https://bikeindex.org/manufacturers.csv -O "${outdir}manufacturers.csv"
 wget -q https://bikeindex.org/primary_activities.csv -O "${outdir}primary_activities.csv"
+wget -q https://bikeindex.org/components.csv -O "${outdir}components.csv"

--- a/data/components.csv
+++ b/data/components.csv
@@ -1,60 +1,61 @@
 name,secondary_name,has_multiple_locations,group
-unknown,,false,Additional Parts
-Water Bottle Cage,,false,Additional Parts
-Stem,Gooseneck,false,Additional Parts
+Aero Bars/Extensions/Bar Ends,Aero Bars,false,Additional Parts
+Axle Nuts,,true,Wheels
 Bashguard/Chain Guide,,false,Drivetrain
-Fairing,,false,Frame and Fork
-Lights,,true,Additional Parts
-Bell/Noisemaker,,false,Additional Parts
 Basket,,true,Cargo
-Chain Tensioners,Chain Tugs,false,Drivetrain
-Derailleur,,false,Drivetrain
-Training Wheels,,false,Wheels
+Bell/Noisemaker,,false,Additional Parts
 Bottom Bracket,,false,Drivetrain
 Brake,,true,Brakes
-Hub Guard,,false,Additional Parts
-Generator/Dynamo,,true,Wheels
-Handlebar,,false,Additional Parts
-Wheel,,true,Wheels
-Saddle,,false,Additional Parts
-Rim,,true,Wheels
-Axle Nuts,,true,Wheels
-Hub,,true,Wheels
-Spokes,,true,Wheels
-Tube,,true,Wheels
-Tire,,true,Wheels
-Brake Lever,,true,Brakes
-Shift and Brake Lever,,true,Drivetrain
-Brake Rotor,,true,Brakes
-Brake Pad,,true,Brakes
-Shifter,,true,Drivetrain
-Fork,,false,Frame and Fork
-Rear Suspension,,false,Frame and Fork
-Headset,,false,Frame and Fork
 Brake Cable,,false,Brakes
-Shift Cable,,false,Drivetrain
+Brake Lever,,true,Brakes
+Brake Pad,,true,Brakes
+Brake Rotor,,true,Brakes
+Cargo Bike Side Rails,Cargo Bike Monkey Bars,false,Cargo
 Chain,,false,Drivetrain
+Chain Tensioners,Chain Tugs,false,Drivetrain
 Chainrings,,false,Drivetrain
+Child Seat,,false,Cargo
 Cog/Cassette/Freewheel,,false,Drivetrain
-Crankset,,false,Drivetrain
-Pedals,,false,Drivetrain
 Computer,,false,Additional Parts
-Pegs,,true,Additional Parts
-Toe Clips,,false,Additional Parts
-Grips/Tape,,false,Additional Parts
-Seatpost Clamp,,false,Additional Parts
+Crankset,,false,Drivetrain
+Derailleur,,false,Drivetrain
 Detangler,,false,Brakes
-Kickstand,,false,Additional Parts
-Rack,,true,Cargo
-Seatpost,,false,Additional Parts
-Fender,,true,Additional Parts
-Aero Bars/Extensions/Bar Ends,Aero Bars,false,Additional Parts
 Ebike Battery,Electric Bike Battery,false,Drivetrain
 Ebike Motor,Electric Bike Motor,false,Drivetrain
-Pannier,Rack Bag,false,Cargo
+Fairing,,false,Frame and Fork
+Fender,,true,Additional Parts
+Fork,,false,Frame and Fork
 Frame Bag,,false,Cargo
-Cargo Bike Side Rails,Cargo Bike Monkey Bars,false,Cargo
+Generator/Dynamo,,true,Wheels
+Grips/Tape,,false,Additional Parts
+Handlebar,,false,Additional Parts
 Handlebar Bag,,false,Cargo
+Headset,,false,Frame and Fork
+Hub,,true,Wheels
+Hub Guard,,false,Additional Parts
+Kickstand,,false,Additional Parts
+Lights,,true,Additional Parts
+Pannier,Rack Bag,false,Cargo
+Pedals,,false,Drivetrain
+Pegs,,true,Additional Parts
+Rack,,true,Cargo
+Rear Suspension,,false,Frame and Fork
+Rim,,true,Wheels
+Saddle,,false,Additional Parts
 Seat Bag,Saddle Bag,false,Cargo
+Seatpost,,false,Additional Parts
+Seatpost Clamp,,false,Additional Parts
+Shift Cable,,false,Drivetrain
+Shift and Brake Lever,,true,Drivetrain
+Shifter,,true,Drivetrain
+Spokes,,true,Wheels
+Stem,Gooseneck,false,Additional Parts
+Tire,,true,Wheels
+Toe Clips,,false,Additional Parts
 Top Tube Bag,Bento Box,false,Cargo
-Child Seat,,false,Cargo
+Top of Rack Bag,Rack Bag,false,Cargo
+Training Wheels,,false,Wheels
+Tube,,true,Wheels
+Water Bottle Cage,,false,Additional Parts
+Wheel,,true,Wheels
+unknown,,false,Additional Parts

--- a/tests/csvs_spec.rb
+++ b/tests/csvs_spec.rb
@@ -9,6 +9,7 @@ system("bin/download_from_bike_index tmp/", exception: true)
 
 BIKE_INDEX_MANUFACTURERS_CSV = CSV.read("tmp/manufacturers.csv", headers: true, header_converters: :symbol)
 BIKE_INDEX_ACTIVITIES_CSV = CSV.read("tmp/primary_activities.csv", headers: true, header_converters: :symbol)
+BIKE_INDEX_COMPONENTS_CSV = CSV.read("tmp/components.csv", headers: true, header_converters: :symbol)
 
 RSpec.describe "CSVs" do
   shared_examples "a data CSV" do |path|
@@ -60,6 +61,13 @@ RSpec.describe "CSVs" do
 
   describe "components.csv" do
     it_behaves_like "a data CSV", "data/components.csv"
+
+    let(:repo_csv) { CSV.read("data/components.csv", headers: true, header_converters: :symbol) }
+
+    it "has at least as many components as are on bikeindex, and the same headers" do
+      expect(repo_csv.count).to eq BIKE_INDEX_COMPONENTS_CSV.count
+      expect(repo_csv.headers).to eq BIKE_INDEX_COMPONENTS_CSV.headers
+    end
   end
 
   describe "vehicle_attributes.csv" do


### PR DESCRIPTION
Adds `components.csv` to the set of CSVs downloaded from bikeindex.org, alongside `manufacturers` and `primary_activities`.

- Fetches `https://bikeindex.org/components.csv` in `bin/download_from_bike_index`.
- Refreshes `data/components.csv` from the canonical copy (now alphabetized, adds `Top of Rack Bag`).
- Upgrades the `components.csv` spec to assert the repo file matches Bike Index's row count and headers.
