### PR TITLE
Add data/brakes.csv with brake types

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,6 +10,7 @@ The data here is used by [BikeIndex.org](https://bikeindex.org) to classify bike
 - Colors: [colors.csv](data/colors.csv)
 - Drivetrain: [drivetrain.csv](data/drivetrain.csv)
 - Handlebar types: [handlebar_types.csv](data/handlebar_types.csv)
+- Brakes: [brakes.csv](data/brakes.csv)
 
 Are we missing a manufacturer? Or missing data about a manufacturer?
 

--- a/data/brakes.csv
+++ b/data/brakes.csv
@@ -1,0 +1,17 @@
+name,secondary_name
+Disc Hydraulic,Hydraulic Disc
+Disc Mechanical,Cable Disc
+Linear Pull,V-Brake
+Caliper,Rim Caliper
+Side Pull,Caliper Side Pull
+Center Pull,Caliper Center Pull
+Cantilever,Canti
+U-Brake,
+Coaster Brake,Back-Pedal Brake
+Drum Brake,
+Roller Brake,
+Band Brake,
+Rod Brake,Stirrup Brake
+Spoon Brake,Plunger Brake
+Hydraulic Rim,
+Delta Brake,

--- a/tests/csvs_spec.rb
+++ b/tests/csvs_spec.rb
@@ -85,4 +85,8 @@ RSpec.describe "CSVs" do
   describe "handlebar_types.csv" do
     it_behaves_like "a data CSV", "data/handlebar_types.csv"
   end
+
+  describe "brakes.csv" do
+    it_behaves_like "a data CSV", "data/brakes.csv"
+  end
 end


### PR DESCRIPTION
Adds a `brakes.csv` taxonomy listing bicycle brake types, with `name` and `secondary_name` columns.

- New `data/brakes.csv` covering disc, rim/cable-actuated, hub, and vintage brake types (Title Case).
- Adds the `brakes.csv` example to `csvs_spec`.
- Links the new file from the README.
