### PR TITLE
Add Cable Actuated Hydraulic to brake_types.csv

### DIFF
--- a/data/brake_types.csv
+++ b/data/brake_types.csv
@@ -15,3 +15,4 @@ Rod Brake,Stirrup Brake
 Spoon Brake,Plunger Brake
 Hydraulic Rim,
 Delta Brake,
+Cable Actuated Hydraulic,Hybrid Disc


### PR DESCRIPTION
Adds a `Cable Actuated Hydraulic` row to the brake types taxonomy.

- New `Cable Actuated Hydraulic,Hybrid Disc` entry in `data/brake_types.csv`, covering brakes with a cable lever feeding a hydraulic caliper.
