### PR TITLE
Alphabetize name-list CSVs and test sort order

### DIFF
--- a/data/brake_types.csv
+++ b/data/brake_types.csv
@@ -1,18 +1,18 @@
 name,secondary_name
+Band Brake,
+Cable Actuated Hydraulic,Hybrid Disc
+Caliper,Rim Caliper
+Cantilever,Canti
+Center Pull,Caliper Center Pull
+Coaster Brake,Back-Pedal Brake
+Delta Brake,
 Disc Hydraulic,Hydraulic Disc
 Disc Mechanical,Cable Disc
-Linear Pull,V-Brake
-Caliper,Rim Caliper
-Side Pull,Caliper Side Pull
-Center Pull,Caliper Center Pull
-Cantilever,Canti
-U-Brake,
-Coaster Brake,Back-Pedal Brake
 Drum Brake,
-Roller Brake,
-Band Brake,
-Rod Brake,Stirrup Brake
-Spoon Brake,Plunger Brake
 Hydraulic Rim,
-Delta Brake,
-Cable Actuated Hydraulic,Hybrid Disc
+Linear Pull,V-Brake
+Rod Brake,Stirrup Brake
+Roller Brake,
+Side Pull,Caliper Side Pull
+Spoon Brake,Plunger Brake
+U-Brake,

--- a/data/component_types.csv
+++ b/data/component_types.csv
@@ -45,17 +45,17 @@ Saddle,,false,Additional Parts
 Seat Bag,Saddle Bag,false,Cargo
 Seatpost,,false,Additional Parts
 Seatpost Clamp,,false,Additional Parts
-Shift Cable,,false,Drivetrain
 Shift and Brake Lever,,true,Drivetrain
+Shift Cable,,false,Drivetrain
 Shifter,,true,Drivetrain
 Spokes,,true,Wheels
 Stem,Gooseneck,false,Additional Parts
 Tire,,true,Wheels
 Toe Clips,,false,Additional Parts
-Top Tube Bag,Bento Box,false,Cargo
 Top of Rack Bag,Rack Bag,false,Cargo
+Top Tube Bag,Bento Box,false,Cargo
 Training Wheels,,false,Wheels
 Tube,,true,Wheels
+unknown,,false,Additional Parts
 Water Bottle Cage,,false,Additional Parts
 Wheel,,true,Wheels
-unknown,,false,Additional Parts

--- a/data/handlebar_types.csv
+++ b/data/handlebar_types.csv
@@ -1,7 +1,7 @@
 name,slug
-Drop Bars,drop_bar
-Forward Facing,forward
-Rear Facing,rearward
-Not Handlebars,other
 BMX Style,bmx
+Drop Bars,drop_bar
 Flat or Riser,flat
+Forward Facing,forward
+Not Handlebars,other
+Rear Facing,rearward

--- a/tests/csvs_spec.rb
+++ b/tests/csvs_spec.rb
@@ -33,8 +33,27 @@ RSpec.describe "CSVs" do
     end
   end
 
+  # Verifies the data rows are sorted case-insensitively by their first column.
+  shared_examples "an alphabetized CSV" do |path|
+    let(:values) { CSV.read(path)[1..].map { |row| row.first.to_s } }
+
+    it "is alphabetized (case-insensitively) by its first column" do
+      sorted = values.sort_by(&:downcase)
+
+      out_of_order = values.each_index.reject { |i| values[i] == sorted[i] }
+        .map { |i| "line #{i + 2}: #{values[i].inspect}" }
+
+      expect(values).to(
+        eq(sorted),
+        "expected rows to be sorted by the first column, but these are out of order: " \
+        "#{out_of_order.join(", ")}"
+      )
+    end
+  end
+
   describe "manufacturers.csv" do
     it_behaves_like "a data CSV", "data/manufacturers.csv"
+    it_behaves_like "an alphabetized CSV", "data/manufacturers.csv"
 
     let(:repo_csv) { CSV.read("data/manufacturers.csv", headers: true, header_converters: :symbol) }
 
@@ -61,6 +80,7 @@ RSpec.describe "CSVs" do
 
   describe "component_types.csv" do
     it_behaves_like "a data CSV", "data/component_types.csv"
+    it_behaves_like "an alphabetized CSV", "data/component_types.csv"
 
     let(:repo_csv) { CSV.read("data/component_types.csv", headers: true, header_converters: :symbol) }
 
@@ -76,6 +96,7 @@ RSpec.describe "CSVs" do
 
   describe "colors.csv" do
     it_behaves_like "a data CSV", "data/colors.csv"
+    it_behaves_like "an alphabetized CSV", "data/colors.csv"
   end
 
   describe "drivetrain_attributes.csv" do
@@ -84,9 +105,11 @@ RSpec.describe "CSVs" do
 
   describe "handlebar_types.csv" do
     it_behaves_like "a data CSV", "data/handlebar_types.csv"
+    it_behaves_like "an alphabetized CSV", "data/handlebar_types.csv"
   end
 
   describe "brake_types.csv" do
     it_behaves_like "a data CSV", "data/brake_types.csv"
+    it_behaves_like "an alphabetized CSV", "data/brake_types.csv"
   end
 end


### PR DESCRIPTION
Alphabetizes the name-list taxonomy CSVs by their first column and adds a test to keep them sorted.

- Sorts `brake_types.csv` and `handlebar_types.csv` (were unsorted) and fixes a few stragglers in `component_types.csv`, all case-insensitively by `name`.
- Adds an `"an alphabetized CSV"` shared example to `csvs_spec`, wired to `brake_types`, `colors`, `component_types`, `handlebar_types`, and `manufacturers`; it reports the offending line numbers on failure.
- Leaves the intentionally-ordered CSVs (`drivetrain_attributes`, `wheel_sizes`, `vehicle_attributes`, `primary_activities`) untouched.
