### PR TITLE
Add ebike charger, display/remote, and wiring harness component types

### DIFF
--- a/bin/download_from_bike_index
+++ b/bin/download_from_bike_index
@@ -1,14 +1,20 @@
 #!/bin/bash
 
-# Default output directory
-outdir="data/"
+# Default output directory: a bare run refreshes the maintained data/ files
+# from bike_index. Pass a different directory (e.g. tmp/) as the first argument
+# to download reference snapshots without touching data/.
+outdir="data"
 
-# Check if an argument was provided (it is the output directory prefix)
+# Check if an argument was provided (it is the output directory)
 if [ $# -ge 1 ]; then
   outdir="$1"
 fi
 
-# Download the files
+# Normalize to a single trailing slash so "data" and "data/" both work
+outdir="${outdir%/}/"
+
+# Download the files. bike_index serves components.csv; the repo maintains it
+# as component_types.csv (see #46), so save it under that name.
 wget -q https://bikeindex.org/manufacturers.csv -O "${outdir}manufacturers.csv"
 wget -q https://bikeindex.org/primary_activities.csv -O "${outdir}primary_activities.csv"
-wget -q https://bikeindex.org/components.csv -O "${outdir}components.csv"
+wget -q https://bikeindex.org/components.csv -O "${outdir}component_types.csv"

--- a/data/component_types.csv
+++ b/data/component_types.csv
@@ -20,11 +20,11 @@ Computer,,false,Additional Parts
 Crankset,,false,Drivetrain
 Derailleur,,false,Drivetrain
 Detangler,,false,Brakes
-Ebike Battery,Electric Bike Battery,false,Drivetrain
-Ebike Charger,Electric Bike Charger,false,Drivetrain
-Ebike Display/Remote,Electric Bike Display,false,Drivetrain
-Ebike Motor,Electric Bike Motor,false,Drivetrain
-Ebike Wiring Harness,Electric Bike Wiring Harness,false,Drivetrain
+e-vehicle Battery,Electric Vehicle Battery,false,Drivetrain
+e-vehicle Charger,Electric Vehicle Charger,false,Drivetrain
+e-vehicle Display/Remote,Electric Vehicle Computer,false,Drivetrain
+e-vehicle Motor,Electric Vehicle Motor,false,Drivetrain
+e-vehicle Wiring Harness,Electric Vehicle Wiring Harness,false,Drivetrain
 Fairing,,false,Frame and Fork
 Fender,,true,Additional Parts
 Fork,,false,Frame and Fork

--- a/data/component_types.csv
+++ b/data/component_types.csv
@@ -21,7 +21,10 @@ Crankset,,false,Drivetrain
 Derailleur,,false,Drivetrain
 Detangler,,false,Brakes
 Ebike Battery,Electric Bike Battery,false,Drivetrain
+Ebike Charger,Electric Bike Charger,false,Drivetrain
+Ebike Display/Remote,Electric Bike Display,false,Drivetrain
 Ebike Motor,Electric Bike Motor,false,Drivetrain
+Ebike Wiring Harness,Electric Bike Wiring Harness,false,Drivetrain
 Fairing,,false,Frame and Fork
 Fender,,true,Additional Parts
 Fork,,false,Frame and Fork

--- a/tests/csvs_spec.rb
+++ b/tests/csvs_spec.rb
@@ -9,7 +9,7 @@ system("bin/download_from_bike_index tmp/", exception: true)
 
 BIKE_INDEX_MANUFACTURERS_CSV = CSV.read("tmp/manufacturers.csv", headers: true, header_converters: :symbol)
 BIKE_INDEX_ACTIVITIES_CSV = CSV.read("tmp/primary_activities.csv", headers: true, header_converters: :symbol)
-BIKE_INDEX_COMPONENTS_CSV = CSV.read("tmp/components.csv", headers: true, header_converters: :symbol)
+BIKE_INDEX_COMPONENTS_CSV = CSV.read("tmp/component_types.csv", headers: true, header_converters: :symbol)
 
 RSpec.describe "CSVs" do
   shared_examples "a data CSV" do |path|


### PR DESCRIPTION
Adds e-vehicle electronics to the component types taxonomy and fixes the bike_index download script.

- Adds `e-vehicle Charger`, `e-vehicle Display/Remote`, and `e-vehicle Wiring Harness` to `data/component_types.csv`, and renames the existing `Ebike Battery`/`Ebike Motor` to the `e-vehicle` form (lowercase prefix, `Electric Vehicle …` secondary names). The `UI/Remote` handlebar HMI maps to `e-vehicle Display/Remote`.
- Fixes `bin/download_from_bike_index` to save the `components.csv` download under the maintained name `component_types.csv` (renamed in #46) instead of dropping a stray `components.csv`, so a bare run refreshes the `data/` files correctly. Also normalizes the output dir's trailing slash.
- Updates `csvs_spec` to read the renamed reference (`tmp/component_types.csv`).
