### PR TITLE
Add e-scooter wheel sizes to wheel_sizes.csv

### DIFF
--- a/data/wheel_sizes.csv
+++ b/data/wheel_sizes.csv
@@ -1,6 +1,9 @@
 name,iso_bsd,priority,description
+8in,93,uncommon,"8in (200 x 50, ETRTO 47-93) smaller e-scooters and hoverboards (Uncommon)"
+8.5in,134,common,"8.5in (8 1/2 x 2, ISO 50-134) Xiaomi M365/Pro and most 8.5in e-scooters (Common)"
 8 x 1 1/4,137,rare,8 x 1 1/4 (Rare)
-10 x 2,152,rare,10 x 2 (Rare)
+10 x 2,152,rare,"10 x 2 (54-152), Ninebot ES and many 10in e-scooters (Rare)"
+11in,165,uncommon,"11in (90/65-6.5; Ninebot Max 10in uses 60/70-6.5) Dualtron, Ninebot Max e-scooters (Uncommon)"
 12in,203,standard,12in (Standard size)
 16in,305,standard,16in (Standard size)
 16 x 1 3/4,317,rare,16 x 1 3/4 (Rare)

--- a/data/wheel_sizes.csv
+++ b/data/wheel_sizes.csv
@@ -2,7 +2,7 @@ name,iso_bsd,priority,description
 8in,93,uncommon,"8in (200 x 50, ETRTO 47-93) smaller e-scooters and hoverboards (Uncommon)"
 8.5in,134,common,"8.5in (8 1/2 x 2, ISO 50-134) Xiaomi M365/Pro and most 8.5in e-scooters (Common)"
 8 x 1 1/4,137,rare,8 x 1 1/4 (Rare)
-10in,152,rare,"10in (10 x 2, 54-152) Ninebot ES and many 10in e-scooters (Rare)"
+10in,152,common,"10in (10 x 2, 54-152) Ninebot ES/Max and many 10in e-scooters (Common)"
 11in,165,uncommon,"11in (90/65-6.5; Ninebot Max 10in uses 60/70-6.5) Dualtron, Ninebot Max e-scooters (Uncommon)"
 12in,203,standard,12in (Standard size)
 16in,305,standard,16in (Standard size)

--- a/data/wheel_sizes.csv
+++ b/data/wheel_sizes.csv
@@ -2,7 +2,7 @@ name,iso_bsd,priority,description
 8in,93,uncommon,"8in (200 x 50, ETRTO 47-93) smaller e-scooters and hoverboards (Uncommon)"
 8.5in,134,common,"8.5in (8 1/2 x 2, ISO 50-134) Xiaomi M365/Pro and most 8.5in e-scooters (Common)"
 8 x 1 1/4,137,rare,8 x 1 1/4 (Rare)
-10 x 2,152,rare,"10 x 2 (54-152), Ninebot ES and many 10in e-scooters (Rare)"
+10in,152,rare,"10in (10 x 2, 54-152) Ninebot ES and many 10in e-scooters (Rare)"
 11in,165,uncommon,"11in (90/65-6.5; Ninebot Max 10in uses 60/70-6.5) Dualtron, Ninebot Max e-scooters (Uncommon)"
 12in,203,standard,12in (Standard size)
 16in,305,standard,16in (Standard size)


### PR DESCRIPTION
Adds e-scooter pneumatic/solid tire sizes to the wheel sizes taxonomy, keyed by ISO BSD (bead seat diameter) and named by the inch size riders use.

- New `8in` (BSD 93, 200 x 50), `8.5in` (BSD 134, Xiaomi M365/Pro and most 8.5in e-scooters), and `11in` (BSD 165, 6.5in-rim Dualtron / Ninebot Max) rows, inserted in `iso_bsd` sort order.
- Renames the existing `10 x 2` (BSD 152) row to `10in` and notes e-scooter usage (Ninebot ES, etc.), rather than duplicating it.
- BSD 134 and 93 carry explicit ETRTO/ISO codes confirmed across sources; BSD 165 is the 6.5in-rim family (6.5in × 25.4 ≈ 165mm) and is the least-certain value. Ninebot markets the Max as "10in" but it shares this wider 165 tire, so it's grouped under `11in`.
