### PR TITLE
Add Pinion gearbox front internal gear options

### DIFF
--- a/data/drivetrain_attributes.csv
+++ b/data/drivetrain_attributes.csv
@@ -33,10 +33,6 @@ rear,13,13,false
 rear,14,14,false
 rear,13 Internal,13,true
 rear,14 Internal,14,true
-rear,15 Internal,15,true
-rear,16 Internal,16,true
-rear,17 Internal,17,true
-rear,18 Internal,18,true
 rear,Continuously Variable,0,true
 both,Belt Drive,1,false
 rear,Coaster Brake,1,true

--- a/data/drivetrain_attributes.csv
+++ b/data/drivetrain_attributes.csv
@@ -33,6 +33,10 @@ rear,13,13,false
 rear,14,14,false
 rear,13 Internal,13,true
 rear,14 Internal,14,true
+rear,15 Internal,15,true
+rear,16 Internal,16,true
+rear,17 Internal,17,true
+rear,18 Internal,18,true
 rear,Continuously Variable,0,true
 both,Belt Drive,1,false
 rear,Coaster Brake,1,true

--- a/data/drivetrain_attributes.csv
+++ b/data/drivetrain_attributes.csv
@@ -4,6 +4,10 @@ front,2,2,false
 front,3,3,false
 front,2 Internal,2,true
 front,3 Internal,3,true
+front,6 Speed Pinion Gearbox,6,true
+front,9 Speed Pinion Gearbox,9,true
+front,12 Speed Pinion Gearbox,12,true
+front,18 Speed Pinion Gearbox,18,true
 rear,1,1,false
 rear,2,2,false
 rear,3,3,false


### PR DESCRIPTION
Adds front-position Pinion gearbox options to the drivetrain taxonomy.

- New `6`, `9`, `12`, and `18 Speed Pinion Gearbox` rows in `data/drivetrain_attributes.csv`, all `internal`, inserted after the existing front internal rows.
